### PR TITLE
feat: 레이아웃과 라우터 구조 정리

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vite-tsconfig-paths": "^6.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       vite:
         specifier: ^7.2.4
         version: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite-tsconfig-paths:
+        specifier: ^6.0.4
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
@@ -1212,6 +1215,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1819,6 +1825,16 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -1869,6 +1885,14 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-tsconfig-paths@6.0.4:
+    resolution: {integrity: sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
@@ -3241,6 +3265,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3885,6 +3911,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -3960,6 +3990,17 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite-tsconfig-paths@6.0.4(typescript@5.9.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
+    optionalDependencies:
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:

--- a/public/svgs/arrow-right.svg
+++ b/public/svgs/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="#C7CBD2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/>
+</svg>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,6 +7,12 @@
     "module": "ESNext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/src/*": ["src/*"],
+      "@/public/*": ["public/*"]
+    },
+
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
 	plugins: [
 		tailwindcss(),
+		tsconfigPaths(),
 	],
 })


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
close #4 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이번 PR에서는 서비스 기본 라우팅 구조와 레이아웃을 정리하고, 404 처리 페이지를 추가했습니다.





### 1. React Router 기반 라우팅 구조 설정

<img width="662" height="263" alt="스크린샷 2026-01-15 오전 3 03 44" src="https://github.com/user-attachments/assets/8fe4114e-7e82-414e-b261-7444b8778232" />

기존의 App.tsx에서 Header, Nav를 제거하고 RootLayout.ts으로 옮겼습니다.
  ✅ path.ts
   **Route Path Map 상수화 (PATH)**
    
  <img width="498" height="444" alt="스크린샷 2026-01-15 오전 3 20 27" src="https://github.com/user-attachments/assets/8c930ec1-65ca-4e35-8d99-b62285860a90" />

  React Router에서 사용하는 경로 문자열을 PATH 상수 객체로 통합 관리했습니다.
    
  라우트 경로를 문자열로 직접 작성하는 대신 상수로 관리하여 오타 및 경로 불일치 문제를 방지했습니다.
  주석도 써놓았으니 이해 안되시면 한번 읽어봐주세요!
  만약 새로운 페이지의 경로를 추가해야한다면 이 파일에서 제일 먼저 추가 부탁드립니다!

  밑에 처럼 사용하시면 됩니다! 앞으론 경로 문자열 사용말고 여기 path.ts의 상수만 이용!)
        <img width="409" height="30" alt="스크린샷 2026-01-15 오전 3 20 58" src="https://github.com/user-attachments/assets/a72cc5fd-10cb-405e-9f0c-3f75cf8decff" />



  ✅ createBrowserRouter 적용
  
   <img width="592" height="575" alt="스크린샷 2026-01-15 오전 3 06 18" src="https://github.com/user-attachments/assets/e1b60ac1-fd53-4ba3-b683-930cd2b5d503" />

   React Router의 createBrowserRouter를 사용해 전체 라우트 트리를 구성했습니다.
    

      
      
   
  ✅ publicRoutes / protectedRoutes 분리


  
  ✅ ProtectedRoute Guard 적용
  
<img width="516" height="347" alt="스크린샷 2026-01-15 오전 3 13 34" src="https://github.com/user-attachments/assets/5ad90134-7c44-4ffd-86f2-9479e1545909" />

  publicRoutes와 protectedRoutes를 분리해 인증 여부에 따른 라우트 접근을 명확하게 관리했습니다.
 인증이 필요한 페이지는 ProtectedRoute(Guard) 아래에 두어, 인증되지 않은 경우 /login으로 리다이렉트되도록 처리했습니다. 
      ( -> 백엔드 연동 이후 수정 예정!)
      
 <img width="516" height="457" alt="스크린샷 2026-01-15 오전 3 23 21" src="https://github.com/user-attachments/assets/10e81015-136b-4cd4-be0c-3153ef43489a" />





 ✅ RootLayout에서 공통 레이아웃(Header/Nav/Modal + Outlet) 처리
  
  최상위 라우트의 Component로 RootLayout을 지정하여, 모든 페이지에서 공통 레이아웃(Header, Navbar, 전역 Modal 등)이 유지되도록 구성했습니다.
   (이전까지 App.tsx에 있던 것들을 옮겼다고 생각하시면 편합니다!)
 <img width="742" height="494" alt="스크린샷 2026-01-15 오전 3 24 54" src="https://github.com/user-attachments/assets/ab7a4164-0042-4d15-b5cc-7897a707109d" />



### 2. 반응형 레이아웃 수정

 기존 고정 레이아웃(w-[375px])을 제거했습니다.
      → 휴대폰 기기마다 화면 너비가 달라 고정 너비 사용 시 레이아웃이 유동적으로 대응하지 못하는 문제가 있었습니다.
        
 화면 크기에 따라 자연스럽게 확장/축소되도록 레이아웃을 개선했습니다.
        
 다만, 데스크탑 등 큰 화면에서 과도하게 넓어지는 것을 방지하기 위해 max-w-2xl을 적용하여 최대 너비를 제한했습니다.
        
 현재 최대 너비 구간에서는 UI가 다소 어색한 부분이 있어 추가 개선이 필요합니다.

  <img width="1606" height="869" alt="스크린샷 2026-01-15 오전 3 28 13" src="https://github.com/user-attachments/assets/3e18a0bd-b31f-42f7-a5eb-e6f503f06374" />




  ✅ 추가로 NavBar의 position을 기존 `absolute`에서 `sticky`로 변경했습니다.
  
 Header는 sticky로 상단에 고정되어 정상 동작했지만, NavBar는 `absolute` 적용 시 스크롤 상황에서 하단에 고정되지 않는 문제가 있었어서 수정하였습니다.
    
<img width="538" height="213" alt="스크린샷 2026-01-15 오전 3 30 03" src="https://github.com/user-attachments/assets/c944c3c4-ff3a-425f-8de5-6445c7807f47" />

**3. NotFoundPage(404) 추가**

  잘못된 경로 접근 시 404 페이지 노출
  
  3초 후 Home 경로로 자동 이동 처리

https://github.com/user-attachments/assets/23d1c377-7cd7-4c30-82f2-c449ac9546e6



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

>
라우터/레이아웃 구조 변경이 크게 포함되어 있어,
관련 파일들을 전반적으로 확인 부탁드립니다.
읽으시다가 이해가 어려운 부분은 편하게 질문 주세요!