### PR TITLE
refactor: 이미지 파일 로직을 useImageFileInput 훅으로 분리

### DIFF
--- a/src/hooks/domain/onboarding/useCameraCapture.ts
+++ b/src/hooks/domain/onboarding/useCameraCapture.ts
@@ -1,0 +1,41 @@
+import { useRef, useState } from 'react';
+import { getWebcamStream } from '@/src/utils/getWebcam';
+
+export const useCameraCapture = () => {
+	const [isCamera, setIsCamera] = useState(false);
+
+	const videoRef = useRef<HTMLVideoElement | null>(null);
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+	const openCamera = async () => {
+		if (!videoRef.current) return;
+
+		const stream = await getWebcamStream();
+		videoRef.current.srcObject = stream;
+		setIsCamera(true);
+	};
+
+	const capturePhoto = (): string | null => {
+		if (!videoRef.current || !canvasRef.current) return null;
+
+		const canvas = canvasRef.current;
+		const video = videoRef.current;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return null;
+
+		canvas.width = video.videoWidth;
+		canvas.height = video.videoHeight;
+		ctx.drawImage(video, 0, 0);
+
+		setIsCamera(false);
+		return canvas.toDataURL('image/png');
+	};
+
+	return {
+		isCamera,
+		videoRef,
+		canvasRef,
+		openCamera,
+		capturePhoto,
+	};
+};

--- a/src/hooks/domain/onboarding/useImageFileInput.ts
+++ b/src/hooks/domain/onboarding/useImageFileInput.ts
@@ -1,0 +1,41 @@
+import { useRef, useState } from 'react';
+import React from 'react';
+
+
+export const useImageFileInput = () => {
+	const [file, setFile] = useState<File | null>(null);
+	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+	const openFilePicker = () => {
+		fileInputRef.current?.click();
+	};
+
+	const handleChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		setFile(file);
+		setPreviewUrl(URL.createObjectURL(file));
+
+		// 동일 파일 재선택 가능하게
+		e.target.value = '';
+	};
+
+	const reset = () => {
+		setFile(null);
+		setPreviewUrl(null);
+	};
+
+	return {
+		file,
+		previewUrl,
+		fileInputRef,
+		openFilePicker,
+		handleChangeFile,
+		reset,
+		setFile,
+		setPreviewUrl,
+	};
+};

--- a/src/hooks/domain/onboarding/usePhotoInput.ts
+++ b/src/hooks/domain/onboarding/usePhotoInput.ts
@@ -1,68 +1,21 @@
-import React from 'react';
-import { useRef, useState  } from 'react';
-import { getWebcamStream } from '@/src/utils/getWebcam';
+import { useCameraCapture } from './useCameraCapture';
+import { useImageFileInput } from './useImageFileInput';
 
 export const usePhotoInput = () => {
-	const [file, setFile] = useState<File | null>(null);
-	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-	const [isCamera, setIsCamera] = useState(false);
+	const image = useImageFileInput();
+	const camera = useCameraCapture();
 
-	const videoRef = useRef<HTMLVideoElement | null>(null);
-	const canvasRef = useRef<HTMLCanvasElement | null>(null);
-	const fileInputRef = useRef<HTMLInputElement | null>(null);
+	const captureFromCamera = () => {
+		const dataUrl = camera.capturePhoto();
+		if (!dataUrl) return;
 
-	/* ---------- gallery ---------- */
-	const openFilePicker = () => {
-		fileInputRef.current?.click();
-	};
-
-	const handleChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const file = e.target.files?.[0];
-		if (!file) return;
-		
-		setFile(file);
-
-		const previewUrl = URL.createObjectURL(file);
-		setPreviewUrl(previewUrl);
-		e.target.value = '';
-	};
-
-	/* ---------- camera ---------- */
-	const openCamera = async () => {
-		if (!videoRef.current) return;
-
-		const stream = await getWebcamStream();
-		videoRef.current.srcObject = stream;
-		setIsCamera(true);
-	};
-
-	const capturePhoto = () => {
-		if (!videoRef.current || !canvasRef.current) return;
-
-		const canvas = canvasRef.current;
-		const video = videoRef.current;
-		const ctx = canvas.getContext('2d');
-		if (!ctx) return;
-
-		canvas.width = video.videoWidth;
-		canvas.height = video.videoHeight;
-		ctx.drawImage(video, 0, 0);
-
-		setPreviewUrl(canvas.toDataURL('image/png'));
-		setIsCamera(false);
+		image.setPreviewUrl(dataUrl);
+		image.setFile(null); // 카메라는 File 없음
 	};
 
 	return {
-		file,
-		previewUrl,
-		isCamera,
-		videoRef,
-		canvasRef,
-		fileInputRef,
-		setFile,
-		openCamera,
-		openFilePicker,
-		handleChangeFile,
-		capturePhoto,
+		...image,
+		...camera,
+		captureFromCamera,
 	};
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#103 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## Profile Image Uploader 컴포넌트 추가

useImageFileInput 훅을 활용해 프로필 이미지 업로드 UI를 분리된 컴포넌트로 구성했습니다.


## 주요 동작

- 숨겨진 <input type="file" />을 ref로 제어

- 버튼 클릭 시 갤러리 오픈

- 이미지 선택 후 즉시 미리보기 렌더링

```
<button onClick={openFilePicker}>사진 선택</button>
{previewUrl && <img src={previewUrl} />}
```


```
const ProfileImageUploader = () => {
  const {
    previewUrl,
    fileInputRef,
    openFilePicker,
    handleChangeFile,
  } = useImageFileInput();

  return (
    <>
      <input
        ref={fileInputRef}
        type="file"
        accept="image/*"
        hidden
        onChange={handleChangeFile}
      />

      <button onClick={openFilePicker}>사진 선택</button>

      {previewUrl && <img src={previewUrl} />}
    </>
  );
};

```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?