### PR TITLE
fix: 에러 처리 로직 개선

### DIFF
--- a/src/apis/common/apiInstance.ts
+++ b/src/apis/common/apiInstance.ts
@@ -117,7 +117,17 @@ axiosInstance.interceptors.response.use(
     
 		const originalRequest : CustomInternalAxiosRequestConfig = error.config;
 		const currentPath = window.location.pathname;
-		if ( !error.response || error.response.status !== 401 || originalRequest._retry) {
+
+		if (!error.response) {
+			return Promise.reject(error);
+		}
+
+		if (error.response.status !== 401) {
+			return Promise.reject(error);
+		}
+
+
+		if ( originalRequest._retry) {
 			if (currentPath !== PATH.LANDING) {
 				window.location.href = PATH.LOGIN.ROOT;
 			}			return Promise.reject(error);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전 로직에서 서버의 응답이 없는 경우에 무조건 로그인 페이지로 이동하도록 되어있었습니다.

```
		if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
			console.error('요청 시간이 초과되었습니다.');
			return Promise.reject(error);
		}
    
		const originalRequest : CustomInternalAxiosRequestConfig = error.config;
		const currentPath = window.location.pathname;
		if ( !error.response || error.response.status !== 401 || originalRequest._retry) {
			if (currentPath !== PATH.LANDING) {
				window.location.href = PATH.LOGIN.ROOT;
			}			return Promise.reject(error);
		}

```

네트워크 에러 처리 전에 타임아웃 에러를 따로 처리 하도록 변경하여, 타임아웃 시에 에러 처리를 가능하도록 수정였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?